### PR TITLE
Add IDbConnection parameter overload to SqlDataConnection.GetDataContext

### DIFF
--- a/src/FSharp.Data.TypeProviders/TypeProviders.fs
+++ b/src/FSharp.Data.TypeProviders/TypeProviders.fs
@@ -655,7 +655,8 @@ type public DataProviders(config:TypeProviderConfig) =
                         let connectionStringExpr = getRuntimeConnectionStringExpr (connectionString, usingConfigFileInfo, configFileNameParam, dataDirectoryParam, resolutionFolderParam)
                         Expr.NewObject(contextType.GetConstructor [| typeof<string> |], [ connectionStringExpr ])))
 
-                      (methodName, [("connectionString",typeof<string>)], (fun (args:Expr list) -> Expr.NewObject(contextType.GetConstructor [| typeof<string> |], [ args.[0] ]))) ]
+                      (methodName, [("connectionString",typeof<string>)], (fun (args:Expr list) -> Expr.NewObject(contextType.GetConstructor [| typeof<string> |], [ args.[0] ])))
+                      (methodName, [("connection",typeof<IDbConnection>)], (fun (args:Expr list) -> Expr.NewObject(contextType.GetConstructor [| typeof<IDbConnection> |], [ args.[0] ]))) ]
                 contextType, contextType.BaseType, staticMethods),
             Some "GetDataContext",
             (FSData.SR.sqlDataConnection()), 

--- a/tests/FSharp.Data.TypeProviders.Tests/SqlDataConnection/SqlDataConnectionTests.fs
+++ b/tests/FSharp.Data.TypeProviders.Tests/SqlDataConnection/SqlDataConnectionTests.fs
@@ -50,11 +50,13 @@ let checkHostedType (hostedType: System.Type) =
         check "ceklc09wlkm6" (hostedType.GetCustomAttributesData().[0].Constructor.DeclaringType.FullName) typeof<TypeProviderXmlDocAttribute>.FullName
         check "ceklc09wlkm7" (hostedType.GetEvents()) [| |]
         check "ceklc09wlkm8" (hostedType.GetFields()) [| |]
-        check "ceklc09wlkm9" [ for m in hostedType.GetMethods() -> m.Name ] [ "GetDataContext" ; "GetDataContext" ]
+        check "ceklc09wlkm9" [ for m in hostedType.GetMethods() -> m.Name ] [ "GetDataContext" ; "GetDataContext"; "GetDataContext" ]
         let m0 = hostedType.GetMethods().[0]
         let m1 = hostedType.GetMethods().[1]
+        let m2 = hostedType.GetMethods().[2]
         check "ceklc09wlkm9b" (m0.GetParameters().Length) 0
         check "ceklc09wlkm9b" (m1.GetParameters().Length) 1
+        check "ceklc09wlkm9b" (m2.GetParameters().Length) 1
         check "ceklc09wlkm9b" (m0.ReturnType.Name) "Northwnd"
         check "ceklc09wlkm9b" (m0.ReturnType.FullName) "FSharp.Data.TypeProviders.SqlDataConnectionApplied+ServiceTypes+SimpleDataContextTypes+Northwnd"
         check "ceklc09wlkm10" (hostedType.GetProperties()) [| |]


### PR DESCRIPTION
In some cases it is useful to reuse an existing DB connection.

For example when you want to mix raw SQL queries (or other DB related TPs) with this type provider it is convenient to reuse the existing connection so you don't have to instantiate a new connection with the connectionString parameter.